### PR TITLE
✨ : updates `ForumMessage` model with foreign key `reply_to`

### DIFF
--- a/apps/forums/models.py
+++ b/apps/forums/models.py
@@ -85,6 +85,13 @@ class ForumThread(models.Model):
 class ForumMessage(models.Model):
     thread = models.ForeignKey(ForumThread, related_name='messages')
     author = models.ForeignKey(settings.AUTH_USER_MODEL, related_name='messages')
+    reply_to = models.ForeignKey(
+        'self',
+        related_name='replies',
+        blank='True',
+        null='True',
+        on_delete=models.CASCADE,
+    )
     text = models.TextField(max_length=3000)
     timestamp = models.DateTimeField(auto_now=True)
     tags = models.ManyToManyField('ForumTag', blank=True)

--- a/apps/forums/models.py
+++ b/apps/forums/models.py
@@ -88,8 +88,8 @@ class ForumMessage(models.Model):
     reply_to = models.ForeignKey(
         'self',
         related_name='replies',
-        blank='True',
-        null='True',
+        blank=True,
+        null=True,
         on_delete=models.CASCADE,
     )
     text = models.TextField(max_length=3000)

--- a/apps/organizations/models.py
+++ b/apps/organizations/models.py
@@ -220,9 +220,9 @@ class BaseAbstractOrganizationMember(HtkBaseModel):
 
     def __str__(self):
         value = (
-            '{organization_name} Member - {member_name} (member_email)'.format(
+            '{organization_name} Member - {member_name} {member_email}'.format(
                 organization_name=self.organization.name,
-                member_name=self.user.profile.get_full_name(),
+                member_name=self.user.get_full_name(),
                 member_email=self.user.email,
             )
         )

--- a/apps/organizations/models.py
+++ b/apps/organizations/models.py
@@ -220,9 +220,9 @@ class BaseAbstractOrganizationMember(HtkBaseModel):
 
     def __str__(self):
         value = (
-            '{organization_name} Member - {member_name} {member_email}'.format(
+            '{organization_name} Member - {member_name} (member_email)'.format(
                 organization_name=self.organization.name,
-                member_name=self.user.get_full_name(),
+                member_name=self.user.profile.get_full_name(),
                 member_email=self.user.email,
             )
         )


### PR DESCRIPTION
### Description
- Adds a `reply_to` ForeignKey to ForumMessages to track messages that are replies to messages similar to replies on other forums such as `skool` and `reddit`. 
- Replies allow for forum users to engage in discussions under a message rather than individual messages under a thread. 
- Fixes code in the `organizations` abstract models so that the organization member can be correctly displayed when the `__str__` method is used. 
- Refer to https://docs.djangoproject.com/en/dev/ref/models/fields/#django.db.models.ForeignKey for more information on the usage of foreign keys in Django models. 