### PR TITLE
feat: Add image metadata support in meta.html and update wrap_data function

### DIFF
--- a/templates/fragments/meta.html
+++ b/templates/fragments/meta.html
@@ -1,9 +1,25 @@
+<meta property="og:title" content="{{ meta.title.content }}">
+<meta name="twitter:title" content="{{ meta.title.content }}">
 {% if meta.description.content %}
 <meta name="description" content="{{ meta.description.content }}">
+<meta property="og:description" content="{{ meta.description.content }}">
+<meta name="twitter:description" content="{{ meta.description.content }}">
+{% endif %}
+{% if meta.canonical_url %}
+<meta property="og:url" content="{{ meta.canonical_url }}">
+<meta name="twitter:url" content="{{ meta.canonical_url }}">
 {% endif %}
 {% if meta.keywords.content %}
 <meta name="keywords" content="{{ meta.keywords.content }}">
 {% endif %}
+{% if meta.image %}
+<meta property="og:image" content="{{ meta.image }}">
+<meta name="twitter:image" content="{{ meta.image }}">
+<meta name="twitter:card" content="summary_large_image">
+{% else %}
+<meta name="twitter:card" content="summary">
+{% endif %}
+
 {# ----- Site Verifications ----- #}
 {% if meta.site_verifications.alexa %}
 <meta name="alexaVerifyID" content="{{ meta.site_verifications.alexa }}"/>

--- a/templates/fragments/meta.html
+++ b/templates/fragments/meta.html
@@ -1,28 +1,26 @@
-<meta property="og:title" content="{{ meta.title.content }}">
-<meta name="twitter:title" content="{{ meta.title.content }}">
+<meta property="og:title" content="{{ meta.title.content }}" />
+<meta name="twitter:title" content="{{ meta.title.content }}" />
 {% if meta.description.content %}
-<meta name="description" content="{{ meta.description.content }}">
-<meta property="og:description" content="{{ meta.description.content }}">
-<meta name="twitter:description" content="{{ meta.description.content }}">
+<meta name="description" content="{{ meta.description.content }}" />
+<meta property="og:description" content="{{ meta.description.content }}" />
+<meta name="twitter:description" content="{{ meta.description.content }}" />
 {% endif %}
 {% if meta.canonical_url %}
-<meta property="og:url" content="{{ meta.canonical_url }}">
-<meta name="twitter:url" content="{{ meta.canonical_url }}">
+<meta property="og:url" content="{{ meta.canonical_url }}" />
+<meta name="twitter:url" content="{{ meta.canonical_url }}" />
 {% endif %}
 {% if meta.keywords.content %}
-<meta name="keywords" content="{{ meta.keywords.content }}">
+<meta name="keywords" content="{{ meta.keywords.content }}" />
 {% endif %}
 {% if meta.image %}
-<meta property="og:image" content="{{ meta.image }}">
-<meta name="twitter:image" content="{{ meta.image }}">
-<meta name="twitter:card" content="summary_large_image">
-{% else %}
-<meta name="twitter:card" content="summary">
+<meta property="og:image" content="{{ meta.image }}" />
+<meta name="twitter:image" content="{{ meta.image }}" />
 {% endif %}
+<meta name="twitter:card" content="summary{% if meta.image %}_large_image{% endif %}" />
 
 {# ----- Site Verifications ----- #}
 {% if meta.site_verifications.alexa %}
-<meta name="alexaVerifyID" content="{{ meta.site_verifications.alexa }}"/>
+<meta name="alexaVerifyID" content="{{ meta.site_verifications.alexa }}" />
 {% endif %}
 {% if meta.site_verifications.bing %}
 <meta name="msvalidate.01" content="{{ meta.site_verifications.bing }}" />

--- a/view_helpers.py
+++ b/view_helpers.py
@@ -160,6 +160,8 @@ def wrap_data(request, data=None):
             'join_value': ',',
             'static_values': {},
         },
+        'image': '',
+        'canonical_url': '',
         'site_verifications': {},
     }
 
@@ -333,22 +335,23 @@ def _update_meta_content(meta_type, value, update_type='set', data=None):
         data = {}
     meta = data.get('meta', {}).get(meta_type)
     if meta:
-        if type(value) in (
-            list,
-            tuple,
-        ):
-            values_list = value
+        # Check if this meta type is list-based by looking for 'inverted' key
+        if 'inverted' in meta:
+            # Handle list-based meta types (title, description, keywords)
+            if type(value) in (list, tuple):
+                values_list = value
+            else:
+                values_list = [value]
+            if update_type == 'set':
+                meta['inverted'] = values_list
+            elif update_type == 'add':
+                meta['inverted'] += values_list
+            else:
+                # unknown update_type
+                pass
         else:
-            values_list = [
-                value,
-            ]
-        if update_type == 'set':
-            meta['inverted'] = values_list
-        elif update_type == 'add':
-            meta['inverted'] += values_list
-        else:
-            # unknown update_type
-            pass
+            # Handle string-based meta types
+            data['meta'][meta_type] = value
     else:
         pass
 
@@ -434,6 +437,16 @@ def add_meta_keywords(keywords, data=None):
     `keywords` must be a list in order of least significant to most significant terms
     """
     _update_meta_content('keywords', keywords, update_type='add', data=data)
+
+
+def set_meta_image(image_url, data=None):
+    """Sets the META image"""
+    _update_meta_content('image', image_url, update_type='set', data=data)
+
+
+def set_meta_canonical_url(canonical_url, data=None):
+    """Sets the META canonical URL"""
+    _update_meta_content('canonical_url', canonical_url, update_type='set', data=data)
 
 
 def add_breadcrumb_mapping(url_name, title, data):

--- a/view_helpers.py
+++ b/view_helpers.py
@@ -337,7 +337,7 @@ def _update_meta_content(meta_type, value, update_type='set', data=None):
     if meta:
         # Check if this meta type is list-based by looking for 'inverted' key
         if 'inverted' in meta:
-            # Handle list-based meta types (title, description, keywords)
+            # Handle list-based meta types (e.g. title, description, keywords)
             if type(value) in (list, tuple):
                 values_list = value
             else:
@@ -350,7 +350,7 @@ def _update_meta_content(meta_type, value, update_type='set', data=None):
                 # unknown update_type
                 pass
         else:
-            # Handle string-based meta types
+            # Handle string-based meta types (e.g. canonical_url, image)
             data['meta'][meta_type] = value
     else:
         pass


### PR DESCRIPTION
For social media sharing, according to [Everything you ever wanted to know about unfurling but were afraid to ask /or/ How to make your site previews look amazing in Slack](https://medium.com/slack-developer-blog/everything-you-ever-wanted-to-know-about-unfurling-but-were-afraid-to-ask-or-how-to-make-your-e64b4bb9254), we need the following:
- Title
- Description
- Image (optional but recommended)
- Canonical URL

Currently we already have support for title and description, but lacking image URL and canonical URL.

This PR:
- Added 'image' key with a 'url' field to the wrap_data function in view_helpers.py.
- Enhanced meta.html to include Open Graph and Twitter card meta tags for images, conditionally rendering based on the presence of the image URL.